### PR TITLE
Disable postEffect; set size to 3 to help with devicePixelRatio

### DIFF
--- a/src/BattleVisualizer/BattleVisualizer.js
+++ b/src/BattleVisualizer/BattleVisualizer.js
@@ -5,6 +5,7 @@ import 'echarts-gl';
 import 'echarts-maps/world';
 
 class BattleVisualizer extends React.Component {
+  SCATTER_GL_SIZE = 3;
   echartsInstance = null;
   constructor(props) {
     super(props)
@@ -170,12 +171,9 @@ class BattleVisualizer extends React.Component {
           type: 'scatterGL',
           progressive: 1e6,
           coordinateSystem: 'geo',
-          symbolSize: 2,
-          zoomScale: 0.002,
+          symbolSize: self.SCATTER_GL_SIZE,
           blendMode: 'lighter',
-          postEffect: {
-            enable: true
-          },
+          
           zlevel: 101
         },
         {


### PR DESCRIPTION
For some reason, scatterGL is rendering inconsistent sizes when it's set to 1, or 2, so depending on the `window.devicePixelRatio` e.g. 1 for regular monitor, 2 for macbook pro display, the higher ratio leads to tinier dots. 

This problem seems to go away for size `3` and up, but it's only been tested on devices with ratio of `1-2`.

Also disabled `postEffect`. Not sure what it does, but now overlapping dots show a stronger color on all displays, which is a desired effect.