### PR TITLE
Switch HelpOverlay to be fullscreen and prominent

### DIFF
--- a/src/BattleVisualizer/BattleVisualizer.js
+++ b/src/BattleVisualizer/BattleVisualizer.js
@@ -123,10 +123,6 @@ class BattleVisualizer extends React.Component {
       });
     });
 
-    this.echartsInstance.on('click', function (params) {
-      console.log(params);
-    });
-
     var option = {
       backgroundColor: '#000',
       geo: {

--- a/src/HelpOverlay/HelpOverlay.css
+++ b/src/HelpOverlay/HelpOverlay.css
@@ -50,43 +50,23 @@ https://stackoverflow.com/a/42136434/7028776
     opacity: 1;
 }
 
-.overlay-content {
-    position: relative;
-    top: 25%;
-    width: 100%;
+.overlay {
+    color:white;
+    height: 100%;
+}
+
+.overlay .title {
     text-align: center;
-    margin-top: 30px;
 }
 
-.overlay a {
-    padding: 8px;
-    text-decoration: none;
-    font-size: 36px;
-    color: #818181;
-    display: block;
-    transition: 0.3s;
+.overlay .helpButtonHelp{
+    position: fixed;
+    top: 50px;
+    right: 20px;
 }
 
-.overlay a:hover, .overlay a:focus {
-    color: #f1f1f1;
-}
-
-.overlay .closebtn {
-    position: absolute;
-    top: 20px;
-    right: 45px;
-    font-size: 60px;
-}
-
-@media screen and (max-height: 450px) {
-  .overlay a {font-size: 20px}
-  .overlay .closebtn {
-    font-size: 40px;
-    top: 15px;
-    right: 35px;
-  }
-}
-
-.overlay h2, .overlay p {
-  color:white;
+.overlay .legendHelp{
+    position: fixed;
+    bottom: 300px;
+    left: 20px;
 }

--- a/src/HelpOverlay/HelpOverlay.css
+++ b/src/HelpOverlay/HelpOverlay.css
@@ -32,3 +32,61 @@
         text-shadow: 0 0 20px #fff, 0 0 30px #ff4da6, 0 0 40px #ff4da6, 0 0 50px #ff4da6, 0 0 60px #ff4da6, 0 0 70px #ff4da6, 0 0 80px #ff4da6;
     }
 }
+
+/*
+Fullscreen overlay
+https://stackoverflow.com/a/42136434/7028776
+*/
+.overlay {
+    height: 100%;
+    width: 100%;
+    position: fixed;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    background-color: rgba(67, 70, 83, 0.6);
+    overflow-x: hidden;
+    transition: 0.5s;
+    opacity: 1;
+}
+
+.overlay-content {
+    position: relative;
+    top: 25%;
+    width: 100%;
+    text-align: center;
+    margin-top: 30px;
+}
+
+.overlay a {
+    padding: 8px;
+    text-decoration: none;
+    font-size: 36px;
+    color: #818181;
+    display: block;
+    transition: 0.3s;
+}
+
+.overlay a:hover, .overlay a:focus {
+    color: #f1f1f1;
+}
+
+.overlay .closebtn {
+    position: absolute;
+    top: 20px;
+    right: 45px;
+    font-size: 60px;
+}
+
+@media screen and (max-height: 450px) {
+  .overlay a {font-size: 20px}
+  .overlay .closebtn {
+    font-size: 40px;
+    top: 15px;
+    right: 35px;
+  }
+}
+
+.overlay h2, .overlay p {
+  color:white;
+}

--- a/src/HelpOverlay/HelpOverlay.css
+++ b/src/HelpOverlay/HelpOverlay.css
@@ -44,7 +44,7 @@ https://stackoverflow.com/a/42136434/7028776
     z-index: 1;
     top: 0;
     left: 0;
-    background-color: rgba(67, 70, 83, 0.6);
+    background-color: rgba(67, 70, 83, 0.8);
     overflow-x: hidden;
     transition: 0.5s;
     opacity: 1;
@@ -57,16 +57,4 @@ https://stackoverflow.com/a/42136434/7028776
 
 .overlay .title {
     text-align: center;
-}
-
-.overlay .helpButtonHelp{
-    position: fixed;
-    top: 50px;
-    right: 20px;
-}
-
-.overlay .legendHelp{
-    position: fixed;
-    bottom: 300px;
-    left: 20px;
 }

--- a/src/HelpOverlay/HelpOverlay.js
+++ b/src/HelpOverlay/HelpOverlay.js
@@ -110,17 +110,16 @@ class FullscreenOverlay extends React.Component {
           <h2>Carta Historia</h2>
           <p>Visualize battles throughout history across the world!</p>
           <h5>Instructions</h5>
-          <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🗺 + 🖱/👆🤏</span><br />Pan & Zoom<br /><br />
-          <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">📈 + ↔</span><br />Resize & Move the Year Filter<br />
+          <p><span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🗺 + 🖱/👆🤏</span><br />Click/Scroll/Tap//Pinch to interact with the map</p>
+          <p><span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🗺🔴🟠🟢 + 🖱/👆</span><br />Each dot on the map is a battle, colored by its date<br />Hover/Click to see info </p>
+          <p><span role="img" aria-labelledby="jsx-a11y/accessible-emoji">⬇📈 + ↔</span><br /><strong>Timeline</strong> (bottom) <br /> Drag to resize & move the timeline on the bottom, to change the range of battles to highlight</p>
           <br />
-          <p><span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🗺 + 🖱/👆🤏</span><b>anywhere to begin</b></p>
-        </div>
-        <div className="container">
-          <div className="row">
-            <div className="col-xs helpButtonHelp">
-              Open this again
-            </div>
-          </div>
+          <br />
+          <p>
+            (<span role="img" aria-labelledby="jsx-a11y/accessible-emoji">💡</span> to reopen this)
+            <br />
+            <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🖱/👆</span><b>anywhere to begin</b>
+          </p>
         </div>
       </div>
     );

--- a/src/HelpOverlay/HelpOverlay.js
+++ b/src/HelpOverlay/HelpOverlay.js
@@ -4,63 +4,68 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import './HelpOverlay.css';
 
-function renderHelpTooltip(props) {
-  return (
-    <Tooltip {...props} >
-      <h4>Carta Historia</h4>
-      <p>Visualize battles throughout history across the world!</p>
-      <h6>Instructions</h6>
-      <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🗺 + 🖱/👆🤏</span><br />Pan & Zoom<br /><br />
-      <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">📈 + ↔</span><br />Resize & Move the Year Filter<br />
-    </Tooltip>
-  );
-}
 
-function renderHouskeepingTooltip(props) {
-  return (
-    <Tooltip {...props} >
-      Author: <a href="http://github.com/halfacat1/" target="_blank" rel="noopener noreferrer">Han Z.</a>
-      <br />
-      <br />
-      Built with:&nbsp;
-      <a href="https://www.echartsjs.com/" target="_blank" rel="noopener noreferrer">ECharts</a>,&nbsp;
-      <a href="https://reactjs.org/" target="_blank" rel="noopener noreferrer">React</a>
-      <br />
-      Powered by: <a href="https://www.wikidata.org/" target="_blank" rel="noopener noreferrer">Wikidata</a>
-    </Tooltip>
-  );
-}
+class HelpOverlay extends React.Component {
+  renderHelpTooltip(props) {
+    return (
+      <Tooltip {...props} >
+        <h4>Carta Historia</h4>
+        <p>Visualize battles throughout history across the world!</p>
+        <h6>Instructions</h6>
+        <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🗺 + 🖱/👆🤏</span><br />Pan & Zoom<br /><br />
+        <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">📈 + ↔</span><br />Resize & Move the Year Filter<br />
+      </Tooltip>
+    );
+  }
+  renderHouskeepingTooltip(props) {
+    return (
+      <Tooltip {...props} >
+        Author: <a href="http://github.com/halfacat1/" target="_blank" rel="noopener noreferrer">Han Z.</a>
+        <br />
+        <br />
+        Built with:&nbsp;
+        <a href="https://www.echartsjs.com/" target="_blank" rel="noopener noreferrer">ECharts</a>,&nbsp;
+        <a href="https://reactjs.org/" target="_blank" rel="noopener noreferrer">React</a>
+        <br />
+        Powered by: <a href="https://www.wikidata.org/" target="_blank" rel="noopener noreferrer">Wikidata</a>
+      </Tooltip>
+    );
+  }
+  render() {
+    let self = this;
+    return (
+      <div className="HelpOverlay">
+        <div className="container">
+          <div className="row">
+            <div className="col-xs HelpOverlayContainer">
+              <OverlayTrigger
+                placement="left"
+                overlay={self.renderHelpTooltip}
+                trigger="click"
+              >
+                <Button variant="outline-light">
+                  <span role="img" className="Glow" aria-labelledby="jsx-a11y/accessible-emoji">💡</span>
+                </Button>
+              </OverlayTrigger>
+            </div>
+            <div className="col-xs HelpOverlayContainer">
+              <OverlayTrigger
+                placement="bottom"
+                overlay={self.renderHouskeepingTooltip}
+                trigger="click"
+              >
+                <Button variant="outline-light">
+                  <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">👋</span>
+                </Button>
+              </OverlayTrigger>
+            </div>
+          </div>
+        </div>
 
-const HelpOverlay = () => (
-  <div className="HelpOverlay">
-    <div className="container">
-      <div className="row">
-        <div className="col-xs HelpOverlayContainer">
-          <OverlayTrigger
-            placement="left"
-            overlay={renderHelpTooltip}
-            trigger="click"
-          >
-            <Button variant="outline-light">
-              <span role="img" className="Glow" aria-labelledby="jsx-a11y/accessible-emoji">💡</span>
-            </Button>
-          </OverlayTrigger>
-        </div>
-        <div className="col-xs HelpOverlayContainer">
-          <OverlayTrigger
-            placement="bottom"
-            overlay={renderHouskeepingTooltip}
-            trigger="click"
-          >
-            <Button variant="outline-light">
-              <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">👋</span>
-            </Button>
-          </OverlayTrigger>
-        </div>
       </div>
-    </div>
+    );
+  }
+}
 
-  </div>
-);
 
 export default HelpOverlay;

--- a/src/HelpOverlay/HelpOverlay.js
+++ b/src/HelpOverlay/HelpOverlay.js
@@ -106,18 +106,20 @@ class FullscreenOverlay extends React.Component {
         style={this.state.style}
         onClick={this.closeFullscreenOverlay}
       >
-        <div className="sidenav-container">
-          <div className="text-center">
-            <h2>Carta Historia</h2>
-            <p>Hello</p>
-            <p>Hello</p>
-            <p>Hello</p>
-            <p>Hello</p>
-            <p>Hello</p>
-            <p>Hello</p>
-            <p>Hello</p>
-            <p>Hello</p>
-            <p>Hello</p>
+        <div className="title">
+          <h2>Carta Historia</h2>
+          <p>Visualize battles throughout history across the world!</p>
+          <h5>Instructions</h5>
+          <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🗺 + 🖱/👆🤏</span><br />Pan & Zoom<br /><br />
+          <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">📈 + ↔</span><br />Resize & Move the Year Filter<br />
+          <br />
+          <p><span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🗺 + 🖱/👆🤏</span><b>anywhere to begin</b></p>
+        </div>
+        <div className="container">
+          <div className="row">
+            <div className="col-xs helpButtonHelp">
+              Open this again
+            </div>
           </div>
         </div>
       </div>

--- a/src/HelpOverlay/HelpOverlay.js
+++ b/src/HelpOverlay/HelpOverlay.js
@@ -14,7 +14,7 @@ class HelpOverlay extends React.Component {
 
     this.toggleFullscreenOverlay = this.toggleFullscreenOverlay.bind(this);
   }
-  toggleFullscreenOverlay(props) {
+  toggleFullscreenOverlay() {
     this.setState({
       showFullscreen: true
     });
@@ -76,13 +76,11 @@ class FullscreenOverlay extends React.Component {
     this.openFullscreenOverlay = this.openFullscreenOverlay.bind(this);
     this.closeFullscreenOverlay = this.closeFullscreenOverlay.bind(this);
   }
-
   componentDidUpdate(prevProps, prevState, snapshot) {
     if (prevProps.show && !prevState.show) {
       this.openFullscreenOverlay();
     }
   }
-
   openFullscreenOverlay() {
     this.setState({
       show: true,
@@ -92,7 +90,6 @@ class FullscreenOverlay extends React.Component {
       }
     });
   }
-
   closeFullscreenOverlay() {
     this.setState({
       show: false,
@@ -102,28 +99,25 @@ class FullscreenOverlay extends React.Component {
       }
     });
   }
-
   render() {
     return (
-      <div id="fullscreen-overlay">
-        <div
-          className="overlay"
-          style={this.state.style}
-        >
-          <Button href="#" onClick={this.closeFullscreenOverlay}>Close</Button>
-          <div className="sidenav-container">
-            <div className="text-center">
-              <h2>Carta Historia</h2>
-              <p>This is a sample input form</p>
-              <p>This is a sample input form</p>
-              <p>This is a sample input form</p>
-              <p>This is a sample input form</p>
-              <p>This is a sample input form</p>
-              <p>This is a sample input form</p>
-              <p>This is a sample input form</p>
-              <p>This is a sample input form</p>
-              <p>This is a sample input form</p>
-            </div>
+      <div
+        className="overlay"
+        style={this.state.style}
+        onClick={this.closeFullscreenOverlay}
+      >
+        <div className="sidenav-container">
+          <div className="text-center">
+            <h2>Carta Historia</h2>
+            <p>Hello</p>
+            <p>Hello</p>
+            <p>Hello</p>
+            <p>Hello</p>
+            <p>Hello</p>
+            <p>Hello</p>
+            <p>Hello</p>
+            <p>Hello</p>
+            <p>Hello</p>
           </div>
         </div>
       </div>

--- a/src/HelpOverlay/HelpOverlay.js
+++ b/src/HelpOverlay/HelpOverlay.js
@@ -38,6 +38,7 @@ class HelpOverlay extends React.Component {
         <div className="container">
           <div className="row">
             <div className="col-xs HelpOverlayContainer">
+              <FullscreenOverlay />
               <OverlayTrigger
                 placement="left"
                 overlay={self.renderHelpTooltip}
@@ -61,11 +62,68 @@ class HelpOverlay extends React.Component {
             </div>
           </div>
         </div>
-
       </div>
     );
   }
 }
 
+class FullscreenOverlay extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      style: {
+        height: '100%',
+        opacity: 1
+      }
+    };
+    this.openFullscreenOverlay = this.openFullscreenOverlay.bind(this);
+    this.closeFullscreenOverlay = this.closeFullscreenOverlay.bind(this);
+  }
+
+  openFullscreenOverlay() {
+    let style = {
+      height: '100%',
+      opacity: 1
+    };
+    this.setState({ style });
+  }
+
+  closeFullscreenOverlay() {
+    let style = {
+      height: 0,
+      opacity: 0,
+    };
+    this.setState({ style });
+  }
+
+  render() {
+    return (
+      <div id="fullscreen-overlay">
+        <span style={{ fontSize: 30, cursor: "pointer" }} onClick={this.openFullscreenOverlay}>&#9776; open</span>
+        <div
+          className="overlay"
+          style={this.state.style}
+        >
+          <Button href="#" className="closebtn" onClick={this.closeFullscreenOverlay}>×</Button>
+          <div className="sidenav-container">
+            <div className="text-center">
+              <h2>Carta Historia</h2>
+              <p>This is a sample input form</p>
+              <p>This is a sample input form</p>
+              <p>This is a sample input form</p>
+              <p>This is a sample input form</p>
+              <p>This is a sample input form</p>
+              <p>This is a sample input form</p>
+              <p>This is a sample input form</p>
+              <p>This is a sample input form</p>
+              <p>This is a sample input form</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
 
 export default HelpOverlay;

--- a/src/HelpOverlay/HelpOverlay.js
+++ b/src/HelpOverlay/HelpOverlay.js
@@ -6,16 +6,18 @@ import './HelpOverlay.css';
 
 
 class HelpOverlay extends React.Component {
-  renderHelpTooltip(props) {
-    return (
-      <Tooltip {...props} >
-        <h4>Carta Historia</h4>
-        <p>Visualize battles throughout history across the world!</p>
-        <h6>Instructions</h6>
-        <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">🗺 + 🖱/👆🤏</span><br />Pan & Zoom<br /><br />
-        <span role="img" aria-labelledby="jsx-a11y/accessible-emoji">📈 + ↔</span><br />Resize & Move the Year Filter<br />
-      </Tooltip>
-    );
+  constructor(props) {
+    super(props);
+    this.state = {
+      showFullscreen: true
+    };
+
+    this.toggleFullscreenOverlay = this.toggleFullscreenOverlay.bind(this);
+  }
+  toggleFullscreenOverlay(props) {
+    this.setState({
+      showFullscreen: true
+    });
   }
   renderHouskeepingTooltip(props) {
     return (
@@ -38,16 +40,10 @@ class HelpOverlay extends React.Component {
         <div className="container">
           <div className="row">
             <div className="col-xs HelpOverlayContainer">
-              <FullscreenOverlay />
-              <OverlayTrigger
-                placement="left"
-                overlay={self.renderHelpTooltip}
-                trigger="click"
-              >
-                <Button variant="outline-light">
-                  <span role="img" className="Glow" aria-labelledby="jsx-a11y/accessible-emoji">💡</span>
-                </Button>
-              </OverlayTrigger>
+              <FullscreenOverlay show={self.state.showFullscreen} />
+              <Button variant="outline-light" onClick={self.toggleFullscreenOverlay}>
+                <span role="img" className="Glow" aria-labelledby="jsx-a11y/accessible-emoji">💡</span>
+              </Button>
             </div>
             <div className="col-xs HelpOverlayContainer">
               <OverlayTrigger
@@ -68,10 +64,10 @@ class HelpOverlay extends React.Component {
 }
 
 class FullscreenOverlay extends React.Component {
-
   constructor(props) {
     super(props);
     this.state = {
+      show: props.show,
       style: {
         height: '100%',
         opacity: 1
@@ -81,31 +77,40 @@ class FullscreenOverlay extends React.Component {
     this.closeFullscreenOverlay = this.closeFullscreenOverlay.bind(this);
   }
 
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (prevProps.show && !prevState.show) {
+      this.openFullscreenOverlay();
+    }
+  }
+
   openFullscreenOverlay() {
-    let style = {
-      height: '100%',
-      opacity: 1
-    };
-    this.setState({ style });
+    this.setState({
+      show: true,
+      style: {
+        height: '100%',
+        opacity: 1
+      }
+    });
   }
 
   closeFullscreenOverlay() {
-    let style = {
-      height: 0,
-      opacity: 0,
-    };
-    this.setState({ style });
+    this.setState({
+      show: false,
+      style: {
+        height: 0,
+        opacity: 0,
+      }
+    });
   }
 
   render() {
     return (
       <div id="fullscreen-overlay">
-        <span style={{ fontSize: 30, cursor: "pointer" }} onClick={this.openFullscreenOverlay}>&#9776; open</span>
         <div
           className="overlay"
           style={this.state.style}
         >
-          <Button href="#" className="closebtn" onClick={this.closeFullscreenOverlay}>×</Button>
+          <Button href="#" onClick={this.closeFullscreenOverlay}>Close</Button>
           <div className="sidenav-container">
             <div className="text-center">
               <h2>Carta Historia</h2>


### PR DESCRIPTION
- Created fullscreen help overlay that displays when page loads
- Dismissed by click/tap anywhere
- Isolate FullscreenOverlay into its own component
- CSS help: https://stackoverflow.com/a/42136434/7028776